### PR TITLE
fix: add server_ipv6_net field to Server struct

### DIFF
--- a/models/server.go
+++ b/models/server.go
@@ -10,27 +10,28 @@ type Subnet struct {
 }
 
 type Server struct {
-	ServerIP     string   `json:"server_ip"`
-	ServerNumber int      `json:"server_number"`
-	ServerName   string   `json:"server_name"`
-	Product      string   `json:"product"`
-	Dc           string   `json:"dc"`
-	Traffic      string   `json:"traffic"`
-	Flatrate     bool     `json:"flatrate"`
-	Status       string   `json:"status"`
-	Throttled    bool     `json:"throttled"`
-	Cancelled    bool     `json:"cancelled"`
-	PaidUntil    string   `json:"paid_until"`
-	IP           []string `json:"ip"`
-	Subnet       []Subnet `json:"subnet"`
-	Reset        bool     `json:"reset"`
-	Rescue       bool     `json:"rescue"`
-	Vnc          bool     `json:"vnc"`
-	Windows      bool     `json:"windows"`
-	Plesk        bool     `json:"plesk"`
-	Cpanel       bool     `json:"cpanel"`
-	Wol          bool     `json:"wol"`
-	HotSwap      bool     `json:"hot_swap"`
+	ServerIP      string   `json:"server_ip"`
+	ServerIPv6Net string   `json:"server_ipv6_net"`
+	ServerNumber  int      `json:"server_number"`
+	ServerName    string   `json:"server_name"`
+	Product       string   `json:"product"`
+	Dc            string   `json:"dc"`
+	Traffic       string   `json:"traffic"`
+	Flatrate      bool     `json:"flatrate"`
+	Status        string   `json:"status"`
+	Throttled     bool     `json:"throttled"`
+	Cancelled     bool     `json:"cancelled"`
+	PaidUntil     string   `json:"paid_until"`
+	IP            []string `json:"ip"`
+	Subnet        []Subnet `json:"subnet"`
+	Reset         bool     `json:"reset"`
+	Rescue        bool     `json:"rescue"`
+	Vnc           bool     `json:"vnc"`
+	Windows       bool     `json:"windows"`
+	Plesk         bool     `json:"plesk"`
+	Cpanel        bool     `json:"cpanel"`
+	Wol           bool     `json:"wol"`
+	HotSwap       bool     `json:"hot_swap"`
 }
 
 type ServerSetNameInput struct {


### PR DESCRIPTION
Thank you for providing that library to the public.
The robot webservice api includes a field for the servers main IPv6 net address (`server_ipv6_net`). This MR adds it to the `Server` struct.